### PR TITLE
meson: fix build with dmd/gcc

### DIFF
--- a/examples/ConfigurationDemo/meson.build
+++ b/examples/ConfigurationDemo/meson.build
@@ -18,7 +18,7 @@ executable(
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )
 
 install_data(

--- a/examples/ContainerDemo/meson.build
+++ b/examples/ContainerDemo/meson.build
@@ -21,5 +21,5 @@ executable('hunt-container-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/LoggerDemo/meson.build
+++ b/examples/LoggerDemo/meson.build
@@ -9,5 +9,5 @@ executable('hunt-logger-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/MimeDemo/meson.build
+++ b/examples/MimeDemo/meson.build
@@ -9,5 +9,5 @@ executable('hunt-mime-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/PerformanceTest/meson.build
+++ b/examples/PerformanceTest/meson.build
@@ -8,7 +8,7 @@ performance_test = executable('hunt-performance-test',
     d_module_versions: d_mod_version,
     d_debug: d_debug,
     include_directories: include_directories('source'),
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )
 
 #Disable for now; gets stuck

--- a/examples/TcpDemo/meson.build
+++ b/examples/TcpDemo/meson.build
@@ -5,7 +5,7 @@ executable('hunt-tcp-client-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )
 
 executable('hunt-tcp-server-demo',
@@ -15,5 +15,5 @@ executable('hunt-tcp-server-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/Timer/meson.build
+++ b/examples/Timer/meson.build
@@ -9,5 +9,5 @@ executable('hunt-timer-demo',
     d_debug: d_debug,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/UdpDemo/meson.build
+++ b/examples/UdpDemo/meson.build
@@ -5,7 +5,7 @@ executable('hunt-udp-client-demo',
     d_module_versions: d_mod_version,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )
 
 executable('hunt-udp-server-demo',
@@ -15,5 +15,5 @@ executable('hunt-udp-server-demo',
     d_module_versions: d_mod_version,
     include_directories: include_directories('source'),
     install: true,
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )

--- a/examples/UnitTest/meson.build
+++ b/examples/UnitTest/meson.build
@@ -35,7 +35,7 @@ hunt_test = executable(
     d_unittest: true,
     d_module_versions: d_mod_version,
     include_directories: include_directories('source'),
-    link_args: '-link-defaultlib-shared',
+    link_args: link_runtime_shared_arg,
 )
 
 test('test-hunt', hunt_test)

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,18 @@ hunt_doc_dir = join_paths(get_option('prefix'), get_option('datadir'), 'doc', 'h
 
 hunt_data_dir = join_paths(get_option('prefix'), get_option('datadir'), 'hunt')
 
+compiler_id = meson.get_compiler('d').get_id()
+
+link_runtime_shared_arg = []
+
+if compiler_id == 'llvm'
+    link_runtime_shared_arg = ['-link-defaultlib-shared']
+elif compiler_id == 'dmd'
+    link_runtime_shared_arg = ['-defaultlib=phobos2', '-debuglib=phobos2']
+elif compiler_id == 'gcc'
+    link_runtime_shared_arg = ['-shared-libphobos']
+endif
+
 subdir('source')
 
 subdir('examples')

--- a/source/hunt/meson.build
+++ b/source/hunt/meson.build
@@ -247,7 +247,7 @@ hunt_lib = library('hunt',
     d_module_versions: d_mod_version,
     d_debug: d_debug,
     include_directories: src_inc,
-    link_args: ['-shared', '-link-defaultlib-shared'],
+    link_args: ['-shared', link_runtime_shared_arg],
 )
 
 hunt_dep = declare_dependency(


### PR DESCRIPTION
All D compilers have different args to link the standard library, libphobos,
in a shared manner. Previously we just hardcoded ldc2's switch for this,
but this commit adjusts this so that it also works with dmd and gdc.