### PR TITLE
Fixes errors and warning while building docs

### DIFF
--- a/source/hunt/event/timer/Common.d
+++ b/source/hunt/event/timer/Common.d
@@ -82,6 +82,7 @@ final class TimingWheel {
         add a Timer into the Wheel
         Params:
             tm  = the timer.
+            wheel = the wheel.
     */
     pragma(inline) void addNewTimer(WheelTimer tm, size_t wheel = 0) {
         size_t index;

--- a/source/hunt/util/Serialize.d
+++ b/source/hunt/util/Serialize.d
@@ -1179,7 +1179,7 @@ alias toJSON = toJson;
 deprecated("Using toObject instead.")
 alias toOBJ = toObject;
 
-////------------------------- toTextString ------
+/// toTextString
 /**
 Takes a tree of JSON values and returns the serialized string.
 


### PR DESCRIPTION
I was getting the following output while trying to build the docs.

```
../../../.dub/packages/hunt-1.6.5/hunt/source/hunt/event/timer/Common.d(86,25):
Warning: Ddoc: parameter count mismatch, expected 2, got 1
../../../.dub/packages/hunt-1.6.5/hunt/source/hunt/util/Serialize.d(1192):
Error: unmatched --- in DDoc comment
```
After the below changes, build docs does not give any errors or warnings.

Thanks for this great project btw.