### PR TITLE
Update package.d

### DIFF
--- a/source/hunt/system/syscall/package.d
+++ b/source/hunt/system/syscall/package.d
@@ -16,7 +16,7 @@ version(Posix):
 
 extern (C) nothrow @nogc size_t syscall(size_t ident, ...);
 
-version(D_InlineAsm_X86_64)
+version(X86_64)
 {
     version(linux) public import hunt.system.syscall.os.Linux;
     else version(OSX) public import hunt.system.syscall.os.OSX;


### PR DESCRIPTION
`gdc` doesn't have `D_InlineAsm_X86_64` as it uses different asm syntax than `dmd`. One can use `version(GNU) version(X86_64)`, but this is unnecessary. as imported modules do not use any assembler, just enum definitions for each system.

Fixes https://github.com/huntlabs/hunt/issues/94