### PR TITLE
fix crash: move stack var bufs and targets into class as static fields

### DIFF
--- a/source/hunt/util/DateTime.d
+++ b/source/hunt/util/DateTime.d
@@ -425,8 +425,8 @@ class DateTime {
             while (_isClockRunning) {
                 tick(cur);
                 cur = 1 - cur;
-                // BUG: Reported defects -@zhangxueping at 2021-05-12T19:17:53+08:00
-                // crashed
+                // TODO: this should be fixed by https://github.com/huntlabs/hunt/pull/97, remove these comments after some time
+                // BUG: Reported defects -@zhangxueping at 2021-05-12T19:17:53+08:00 crashed
                 Thread.sleep(1.seconds);
             }
         });

--- a/source/hunt/util/DateTime.d
+++ b/source/hunt/util/DateTime.d
@@ -14,6 +14,7 @@ module hunt.util.DateTime;
 import core.atomic;
 import core.stdc.time;
 import core.thread : Thread;
+import std.array;
 import std.datetime;
 import std.format : formattedWrite;
 import std.string;
@@ -403,11 +404,10 @@ class DateTime {
     private __gshared Thread dateThread;
     private static shared bool _isClockRunning = false;
 
-    shared static this() {
-        import std.array;
+    private static Appender!(char[])[2] bufs;
+    private static const(char)[][2] targets;
 
-        Appender!(char[])[2] bufs;
-        const(char)[][2] targets;
+    shared static this() {
 
         void tick(size_t index) {
             bufs[index].clear();


### PR DESCRIPTION
fix https://github.com/huntlabs/hunt/issues/96

in the old code: the `dateThread` is access stack variable (via the func `tick()` call), 

https://github.com/huntlabs/hunt/blob/master/source/hunt/util/DateTime.d#L423

which causing crash during druntime shutdown. Now move them into class as static fields.
